### PR TITLE
Add Support for JRuby

### DIFF
--- a/lib/rspec_api_documentation/writers/formatter.rb
+++ b/lib/rspec_api_documentation/writers/formatter.rb
@@ -3,7 +3,7 @@ module RspecApiDocumentation
     module Formatter
 
       def self.to_json(object)
-        JSON.pretty_generate(object.as_json)
+        JSON.generate(object.as_json)
       end
 
     end


### PR DESCRIPTION
There is currently a JRuby incompatibility, as `JSON.pretty_generate` currently
has an unresolved bug in JRuby.

Switch to `JSON.generate` in order to resolve this issue. This will make git
diffs more difficult to read for the time being.